### PR TITLE
Feature – Plugin options (log tags, log destination)

### DIFF
--- a/proper_log.php
+++ b/proper_log.php
@@ -13,11 +13,22 @@ function proper_log_activate() {
     if (false === get_option('proper_log_destination')) {
         add_option('proper_log_destination', 'syslog');
     }
+    // Ensure a default tag exists
+    if (false === get_option('proper_log_tag')) {
+        add_option('proper_log_tag', 'ProperLog');
+    }
 }
 
 /* --- Settings UI --- */
 add_action('admin_menu', 'proper_log_admin_menu');
 add_action('admin_init', 'proper_log_settings_init');
+
+add_filter('plugin_action_links_' . plugin_basename(__FILE__), 'proper_log_plugin_action_links');
+function proper_log_plugin_action_links($links) {
+    $settings_link = '<a href="options-general.php?page=proper-log">Settings</a>';
+    array_unshift($links, $settings_link);
+    return $links;
+}
 
 function proper_log_admin_menu() {
     if (current_user_can('manage_options')) {
@@ -36,6 +47,10 @@ function proper_log_settings_init() {
         'sanitize_callback' => 'sanitize_text_field',
         'default' => 'syslog',
     ));
+    register_setting('proper_log', 'proper_log_tag', array(
+        'sanitize_callback' => 'sanitize_text_field',
+        'default' => 'ProperLog',
+    ));
 
     add_settings_section(
         'proper_log_main_section',
@@ -51,6 +66,21 @@ function proper_log_settings_init() {
         'proper_log',
         'proper_log_main_section'
     );
+    add_settings_field(
+        'proper_log_tag_field',
+        'Log tag',
+        'proper_log_tag_field_render',
+        'proper_log',
+        'proper_log_main_section'
+    );
+}
+
+function proper_log_tag_field_render() {
+    $val = get_option('proper_log_tag', 'ProperLog');
+    ?>
+    <input type="text" name="proper_log_tag" value="<?php echo esc_attr($val); ?>" class="regular-text" />
+    <p class="description">Identifier prepended to stdout messages and used as the syslog ident (default: ProperLog).</p>
+    <?php
 }
 
 function proper_log_destination_field_render() {
@@ -93,7 +123,7 @@ function proper_log($args){
     $message = implode(" - ", $log) . "\n";
 
     $dest = get_option('proper_log_destination', 'syslog');
-    $tag = 'ProperLog';
+    $tag = get_option('proper_log_tag', 'ProperLog');
 
     if ($dest === 'stdout') {
         // Try STDOUT constant first (CLI), otherwise use php://stdout

--- a/proper_log.php
+++ b/proper_log.php
@@ -1,28 +1,30 @@
 <?php
 /*
-Plugin Name: Proper Log
-Plugin URI: http://www.swarthmore.edu/its
-Description: Creates a real file based event log. Requires "Activity Log" @ https://wordpress.org/plugins/aryo-activity-log - Created out of Les Leach's frustration of WordPress' lack of logging capabilities
-*/
+ * Plugin Name: Proper Log
+ * Plugin URI: http://www.swarthmore.edu/its
+ * Description: Creates a real file based event log. Requires "Activity Log" @ https://wordpress.org/plugins/aryo-activity-log - Created out of Les Leach's frustration of WordPress' lack of logging capabilities
+ */
 
 add_action("aal_insert_log", "proper_log", 5, 1);
 
-// Ensure a default option is created on activation
+// Default plugin settings
 register_activation_hook(__FILE__, 'proper_log_activate');
 function proper_log_activate() {
+    // Ensure a default logging destination exists
     if (false === get_option('proper_log_destination')) {
         add_option('proper_log_destination', 'syslog');
     }
-    // Ensure a default tag exists
+    // Ensure a default logging tag exists
     if (false === get_option('proper_log_tag')) {
         add_option('proper_log_tag', 'ProperLog');
     }
 }
 
-/* --- Settings UI --- */
+// Settings UI
 add_action('admin_menu', 'proper_log_admin_menu');
 add_action('admin_init', 'proper_log_settings_init');
 
+// Add a "Settings" link on the Dashboard > Plugins page
 add_filter('plugin_action_links_' . plugin_basename(__FILE__), 'proper_log_plugin_action_links');
 function proper_log_plugin_action_links($links) {
     $settings_link = '<a href="options-general.php?page=proper-log">Settings</a>';
@@ -30,6 +32,7 @@ function proper_log_plugin_action_links($links) {
     return $links;
 }
 
+// Admin menu for plugin settings
 function proper_log_admin_menu() {
     if (current_user_can('manage_options')) {
         add_options_page(
@@ -42,6 +45,7 @@ function proper_log_admin_menu() {
     }
 }
 
+// Settings initialization
 function proper_log_settings_init() {
     register_setting('proper_log', 'proper_log_destination', array(
         'sanitize_callback' => 'sanitize_text_field',
@@ -75,6 +79,7 @@ function proper_log_settings_init() {
     );
 }
 
+// Settings field renderers
 function proper_log_tag_field_render() {
     $val = get_option('proper_log_tag', 'ProperLog');
     ?>
@@ -91,6 +96,7 @@ function proper_log_destination_field_render() {
     <?php
 }
 
+// Options page
 function proper_log_options_page() {
     if (!current_user_can('manage_options')) {
         return;
@@ -109,7 +115,7 @@ function proper_log_options_page() {
     <?php
 }
 
-/* --- Logging --- */
+// Logging function
 function proper_log($args){
     // Prefer WP helper to parse the site URL host
     $site_host = wp_parse_url(get_site_url(), PHP_URL_HOST);

--- a/proper_log.php
+++ b/proper_log.php
@@ -118,15 +118,37 @@ function proper_log($args){
         $site_host = preg_replace('/^https?:\/\/(.+)$/', '$1', get_site_url());
     }
     $site_name = $site_host;
+
+    // Validate presence of expected keys to avoid notices
+    $hist_ip     = isset($args['hist_ip'])     ? $args['hist_ip']     : '';
+    $user_id     = isset($args['user_id'])     ? intval($args['user_id']) : 0;
+    $object_type = isset($args['object_type']) ? $args['object_type'] : '';
+    $action      = isset($args['action'])      ? $args['action']      : '';
+    $object_name = isset($args['object_name']) ? $args['object_name'] : '';
+    $object_id   = isset($args['object_id'])   ? $args['object_id']   : '';
+
     $log = array();
     $log[] = $site_name;
-    $log[] = $args['hist_ip'];
-    $uobj = get_user_by ('ID', $args['user_id']);
-    $log[] =  $args['user_id'] . (($uobj) ? " (" . $uobj->data->user_login . " - " . implode(", ", $uobj->roles) . ")" : "");
-    $log[] = $args['object_type'];
-    $log[] = $args['action'];
-    $log[] = $args['object_name'] .((empty($args['object_id'])) ? "" : " (ID: " . $args['object_id'] . ")");
-    $message = implode(" - ", $log) . "\n";
+    $log[] = $hist_ip;
+
+    // Build user info safely
+    $user_info = '';
+    if ($user_id) {
+        $uobj = get_user_by('ID', $user_id);
+        $user_info = (string)$user_id;
+        if ($uobj) {
+            $login = isset($uobj->data->user_login) ? $uobj->data->user_login : '';
+            $roles = isset($uobj->roles) ? implode(', ', $uobj->roles) : '';
+            $user_info .= ($login || $roles) ? " ({$login}" . ($roles ? " - {$roles}" : '') . ")" : '';
+        }
+    }
+    $log[] = $user_info;
+    $log[] = $object_type;
+    $log[] = $action;
+    $log[] = $object_name . ((string) $object_id === '' ? '' : " (ID: " . $object_id . ")");
+
+    // Remove empty segments so messages are cleaner
+    $message = implode(" - ", array_filter($log, function($v){ return $v !== '' && $v !== null; })) . "\n";
 
     $dest = get_option('proper_log_destination', 'syslog');
     $tag = get_option('proper_log_tag', 'ProperLog');
@@ -134,15 +156,15 @@ function proper_log($args){
     if ($dest === 'stdout') {
         // Try STDOUT constant first (CLI), otherwise use php://stdout
         $out_msg = $tag . ': ' . $message;
-      if (defined('STDOUT')) {
-          @fwrite(STDOUT, $out_msg);
-      } else {
-          $out = @fopen('php://stdout', 'w');
-          if ($out) {
-              @fwrite($out, $out_msg);
-              @fclose($out);
-          }
-      }
+        if (defined('STDOUT')) {
+            @fwrite(STDOUT, $out_msg);
+        } else {
+            $out = @fopen('php://stdout', 'w');
+            if ($out) {
+                @fwrite($out, $out_msg);
+                @fclose($out);
+            }
+        }
     } else {
         @openlog($tag, LOG_NDELAY, LOG_LOCAL0);
         @syslog(LOG_INFO, $message);

--- a/proper_log.php
+++ b/proper_log.php
@@ -111,7 +111,13 @@ function proper_log_options_page() {
 
 /* --- Logging --- */
 function proper_log($args){
-    $site_name = preg_replace('/^https?:\/\/(.+)$/', "$1", get_site_url());
+    // Prefer WP helper to parse the site URL host
+    $site_host = wp_parse_url(get_site_url(), PHP_URL_HOST);
+    if (empty($site_host)) {
+        // fallback to regex if parsing fails
+        $site_host = preg_replace('/^https?:\/\/(.+)$/', '$1', get_site_url());
+    }
+    $site_name = $site_host;
     $log = array();
     $log[] = $site_name;
     $log[] = $args['hist_ip'];

--- a/proper_log.php
+++ b/proper_log.php
@@ -7,17 +7,109 @@ Description: Creates a real file based event log. Requires "Activity Log" @ http
 
 add_action("aal_insert_log", "proper_log", 5, 1);
 
+// Ensure a default option is created on activation
+register_activation_hook(__FILE__, 'proper_log_activate');
+function proper_log_activate() {
+    if (false === get_option('proper_log_destination')) {
+        add_option('proper_log_destination', 'syslog');
+    }
+}
+
+/* --- Settings UI --- */
+add_action('admin_menu', 'proper_log_admin_menu');
+add_action('admin_init', 'proper_log_settings_init');
+
+function proper_log_admin_menu() {
+    if (current_user_can('manage_options')) {
+        add_options_page(
+            'Proper Log',
+            'Proper Log',
+            'manage_options',
+            'proper-log',
+            'proper_log_options_page'
+        );
+    }
+}
+
+function proper_log_settings_init() {
+    register_setting('proper_log', 'proper_log_destination', array(
+        'sanitize_callback' => 'sanitize_text_field',
+        'default' => 'syslog',
+    ));
+
+    add_settings_section(
+        'proper_log_main_section',
+        'Logging Destination',
+        function(){ echo '<p>Choose where to send logs.</p>'; },
+        'proper_log'
+    );
+
+    add_settings_field(
+        'proper_log_destination_field',
+        'Destination',
+        'proper_log_destination_field_render',
+        'proper_log',
+        'proper_log_main_section'
+    );
+}
+
+function proper_log_destination_field_render() {
+    $val = get_option('proper_log_destination', 'syslog');
+    ?>
+    <label><input type="radio" name="proper_log_destination" value="syslog" <?php checked($val, 'syslog'); ?>> Syslog</label><br>
+    <label><input type="radio" name="proper_log_destination" value="stdout" <?php checked($val, 'stdout'); ?>> STDOUT (php://stdout)</label>
+    <?php
+}
+
+function proper_log_options_page() {
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+    ?>
+    <div class="wrap">
+        <h1>Proper Log</h1>
+        <form action="options.php" method="post">
+            <?php
+            settings_fields('proper_log');
+            do_settings_sections('proper_log');
+            submit_button();
+            ?>
+        </form>
+    </div>
+    <?php
+}
+
+/* --- Logging --- */
 function proper_log($args){
-	 $site_name = preg_replace('/^https?:\/\/(.+)$/', "$1", get_site_url());
-	 $log = array();
-	 $log[] = $site_name;
-	 $log[] = $args['hist_ip'];
-	 $uobj = get_user_by ('ID', $args['user_id']);
-	 $log[] =  $args['user_id'] . (($uobj) ? " (" . $uobj->data->user_login . " - " . implode(", ", $uobj->roles) . ")" : "");
-	 $log[] = $args['object_type'];
-	 $log[] = $args['action'];
-	 $log[] = $args['object_name'] .((empty($args['object_id'])) ? "" : " (ID: " . $args['object_id'] . ")");
-	 @openlog("WordPress", LOG_NDELAY, LOG_LOCAL0); 
-	 @syslog(LOG_INFO, implode(" - ", $log) . "\n");
-	 @closelog();
+    $site_name = preg_replace('/^https?:\/\/(.+)$/', "$1", get_site_url());
+    $log = array();
+    $log[] = $site_name;
+    $log[] = $args['hist_ip'];
+    $uobj = get_user_by ('ID', $args['user_id']);
+    $log[] =  $args['user_id'] . (($uobj) ? " (" . $uobj->data->user_login . " - " . implode(", ", $uobj->roles) . ")" : "");
+    $log[] = $args['object_type'];
+    $log[] = $args['action'];
+    $log[] = $args['object_name'] .((empty($args['object_id'])) ? "" : " (ID: " . $args['object_id'] . ")");
+    $message = implode(" - ", $log) . "\n";
+
+    $dest = get_option('proper_log_destination', 'syslog');
+    $tag = 'ProperLog';
+
+    if ($dest === 'stdout') {
+        // Try STDOUT constant first (CLI), otherwise use php://stdout
+        $out_msg = $tag . ': ' . $message;
+      if (defined('STDOUT')) {
+          @fwrite(STDOUT, $out_msg);
+      } else {
+          $out = @fopen('php://stdout', 'w');
+          if ($out) {
+              @fwrite($out, $out_msg);
+              @fclose($out);
+          }
+      }
+    } else {
+        @openlog($tag, LOG_NDELAY, LOG_LOCAL0);
+        @syslog(LOG_INFO, $message);
+        @closelog();
+    }
 }


### PR DESCRIPTION
This PR adds plugin options that allow the same plugin to be used on our sites regardless of whether the site has been containerized.

**Plugin settings management and UI:**

* Introduced a settings page in the WordPress admin for configuring the log destination (syslog or stdout) and log tag.
* Added plugin activation hook to set default options (`proper_log_destination` and `proper_log_tag`) if they don't exist.
* Added a "Settings" link to the plugin list for quick access to the configuration page.
* Avoid PHP notices by validating array keys, and improve user info formatting.
* Cleaned up log message formatting by removing potential empty segments for more readable logs.